### PR TITLE
test: verify login interactor with factory-based hashed users

### DIFF
--- a/src/test/java/use_case/login/LoginInteractorTest.java
+++ b/src/test/java/use_case/login/LoginInteractorTest.java
@@ -1,5 +1,7 @@
 package use_case.login;
 
+import entity.CommonUser;
+import entity.CommonUserFactory;
 import entity.User;
 import org.junit.Test;
 import util.PasswordHasher;
@@ -31,6 +33,39 @@ public class LoginInteractorTest {
         @Override public String getPassword() { return pwd; }
     }
 
+    /**
+     * A {@link CommonUserFactory} that assumes the provided password is already hashed.
+     * This mimics the production flow where {@link entity.UserFactory} is used to
+     * reconstruct users from stored credentials without rehashing the password.
+     */
+    private static class PassThroughFactory extends CommonUserFactory {
+        @Override
+        public User createUser(String name, String password) {
+            return new CommonUser(name, password);
+        }
+    }
+
+    /**
+     * An in-memory DAO that stores hashed passwords and uses a {@link CommonUserFactory}
+     * to recreate user objects when retrieved, mirroring the real data access layer.
+     */
+    private static class FactoryUserDAO implements LoginUserDataAccessInterface {
+        private final Map<String, String> users = new HashMap<>();
+        private final CommonUserFactory factory;
+        private String current;
+
+        FactoryUserDAO(CommonUserFactory factory) { this.factory = factory; }
+
+        @Override public boolean existsByName(String username) { return users.containsKey(username); }
+        @Override public void save(User user) { users.put(user.getUsername(), user.getPassword()); }
+        @Override public User get(String username) {
+            String pwd = users.get(username);
+            return pwd != null ? factory.createUser(username, pwd) : null;
+        }
+        @Override public String getCurrentUsername() { return current; }
+        @Override public void setCurrentUsername(String username) { current = username; }
+    }
+
     @Test
     public void failWhenUserMissing() {
         InMemoryUserDAO dao = new InMemoryUserDAO();
@@ -59,5 +94,31 @@ public class LoginInteractorTest {
         interactor.execute(new LoginInputData("bob", "123"));
         assertEquals("bob", presenter.successData.getUsername());
         assertEquals("bob", dao.getCurrentUsername());
+    }
+
+    /**
+     * Ensure that when a user is created and retrieved via {@link CommonUserFactory},
+     * login succeeds with the correct credentials and fails otherwise.
+     */
+    @Test
+    public void loginWithFactoryCreatedHashedUser() {
+        PassThroughFactory factory = new PassThroughFactory();
+        FactoryUserDAO dao = new FactoryUserDAO(factory);
+
+        // Create and store a user whose password has already been hashed
+        String hashed = PasswordHasher.hash("secret");
+        dao.save(factory.createUser("dave", hashed));
+
+        TestPresenter presenter = new TestPresenter();
+        LoginInteractor interactor = new LoginInteractor(dao, presenter);
+
+        // Successful login with correct password
+        interactor.execute(new LoginInputData("dave", "secret"));
+        assertEquals("dave", presenter.successData.getUsername());
+
+        // Failed login with incorrect password
+        presenter.successData = null; presenter.failMessage = null;
+        interactor.execute(new LoginInputData("dave", "wrong"));
+        assertEquals("Incorrect password for dave", presenter.failMessage);
     }
 }


### PR DESCRIPTION
## Summary
- add a pass-through CommonUserFactory and DAO to mimic hashed user retrieval
- verify LoginInteractor succeeds with correct credentials and fails with incorrect ones