### PR TITLE
Avoid rehashing passwords when retrieving users

### DIFF
--- a/src/main/java/data_access/DBUserDataAccessObject.java
+++ b/src/main/java/data_access/DBUserDataAccessObject.java
@@ -121,7 +121,7 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface,
             JSONObject userJson = fetchUser(username);
             if (userJson == null) return null;
             String password = userJson.getString("password");
-            return factory.createUser(username, password);
+            return factory.createUserWithHashedPassword(username, password);
         } catch (IOException e) {
             e.printStackTrace();
             return null;

--- a/src/main/java/entity/CommonUserFactory.java
+++ b/src/main/java/entity/CommonUserFactory.java
@@ -9,4 +9,9 @@ public class CommonUserFactory implements UserFactory {
     public User createUser(String name, String password) {
         return new CommonUser(name, PasswordHasher.hash(password));
     }
+
+    @Override
+    public User createUserWithHashedPassword(String name, String hashedPassword) {
+        return new CommonUser(name, hashedPassword);
+    }
 }

--- a/src/main/java/entity/UserFactory.java
+++ b/src/main/java/entity/UserFactory.java
@@ -6,4 +6,9 @@ package entity;
 public interface UserFactory {
 
     User createUser(String name, String password);
+
+    /**
+     * Creates a user when the provided password is already hashed.
+     */
+    User createUserWithHashedPassword(String name, String hashedPassword);
 }

--- a/src/test/java/entity/CommonUserFactoryTest.java
+++ b/src/test/java/entity/CommonUserFactoryTest.java
@@ -14,4 +14,14 @@ public class CommonUserFactoryTest {
         assertEquals("charlie", user.getUsername());
         assertEquals(PasswordHasher.hash("secret"), user.getPassword());
     }
+
+    @Test
+    public void factoryCreatesUserWithHashedPassword() {
+        CommonUserFactory factory = new CommonUserFactory();
+        String hashed = PasswordHasher.hash("secret");
+        User user = factory.createUserWithHashedPassword("charlie", hashed);
+        assertTrue(user instanceof CommonUser);
+        assertEquals("charlie", user.getUsername());
+        assertEquals(hashed, user.getPassword());
+    }
 }

--- a/src/test/java/use_case/change_password/ChangePasswordInteractorTest.java
+++ b/src/test/java/use_case/change_password/ChangePasswordInteractorTest.java
@@ -21,6 +21,10 @@ public class ChangePasswordInteractorTest {
         @Override public User createUser(String name, String password) {
             return new SimpleUser(name, PasswordHasher.hash(password));
         }
+
+        @Override public User createUserWithHashedPassword(String name, String hashedPassword) {
+            return new SimpleUser(name, hashedPassword);
+        }
     }
     private static class SimpleUser implements User {
         String name, pwd;

--- a/src/test/java/use_case/signup/SignupInteractorTest.java
+++ b/src/test/java/use_case/signup/SignupInteractorTest.java
@@ -37,6 +37,10 @@ public class SignupInteractorTest {
         @Override public User createUser(String name, String password) {
             return new SimpleUser(name, PasswordHasher.hash(password));
         }
+
+        @Override public User createUserWithHashedPassword(String name, String hashedPassword) {
+            return new SimpleUser(name, hashedPassword);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Build users from stored hashed passwords instead of rehashing during DB retrieval
- Extend `UserFactory` with `createUserWithHashedPassword` and implement in `CommonUserFactory`
- Update unit tests and factories for new factory method