### PR TITLE
Broaden test coverage across data access, adapters, and views

### DIFF
--- a/src/test/java/data_access/DBChangePasswordDataAccessObjectTest.java
+++ b/src/test/java/data_access/DBChangePasswordDataAccessObjectTest.java
@@ -1,0 +1,24 @@
+package data_access;
+
+import entity.User;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class DBChangePasswordDataAccessObjectTest {
+    @Test
+    public void changePasswordDoesNotThrow() {
+        DBChangePasswordDataAccessObject dao = new DBChangePasswordDataAccessObject();
+        User user = new User() {
+            @Override
+            public String getUsername() { return "alice"; }
+            @Override
+            public String getPassword() { return "pass"; }
+        };
+        try {
+            dao.changePassword(user);
+        } catch (Exception e) {
+            fail("Should not throw any exception");
+        }
+    }
+}

--- a/src/test/java/data_access/DBFriendRequestDataAccessObjectTest.java
+++ b/src/test/java/data_access/DBFriendRequestDataAccessObjectTest.java
@@ -1,0 +1,74 @@
+package data_access;
+
+import entity.User;
+import entity.UserFactory;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class DBFriendRequestDataAccessObjectTest {
+    private static class SimpleUser implements User {
+        private final String username;
+        private final String password;
+        SimpleUser(String username, String password) { this.username = username; this.password = password; }
+        @Override public String getUsername() { return username; }
+        @Override public String getPassword() { return password; }
+    }
+    private static class InMemoryUserDAO extends DBUserDataAccessObject {
+        private final Map<String, User> store = new HashMap<>();
+        InMemoryUserDAO() { super(new UserFactory() {
+            @Override public User createUser(String name, String password) { return new SimpleUser(name, password); }
+            @Override public User createUserWithHashedPassword(String name, String hashedPassword) { return new SimpleUser(name, hashedPassword); }
+        }); }
+        @Override public void save(User user) { store.put(user.getUsername(), user); }
+        @Override public User get(String username) { return store.get(username); }
+    }
+
+    @Test
+    public void getUserDelegatesToInnerDao() {
+        InMemoryUserDAO userDao = new InMemoryUserDAO();
+        SimpleUser u = new SimpleUser("alice", "pw");
+        userDao.save(u);
+        DBFriendRequestDataAccessObject dao = new DBFriendRequestDataAccessObject(userDao);
+        assertEquals(u, dao.getUser("alice"));
+    }
+
+    @Test
+    public void areFriendsReturnsFalseWhenOffline() {
+        DBFriendRequestDataAccessObject dao = new DBFriendRequestDataAccessObject(new InMemoryUserDAO());
+        assertFalse(dao.areFriends("a", "b"));
+    }
+
+    @Test
+    public void hasFriendRequestReturnsFalseWhenOffline() {
+        DBFriendRequestDataAccessObject dao = new DBFriendRequestDataAccessObject(new InMemoryUserDAO());
+        assertFalse(dao.hasFriendRequest("a", "b"));
+    }
+
+    @Test
+    public void sendFriendRequestThrowsWhenOffline() {
+        DBFriendRequestDataAccessObject dao = new DBFriendRequestDataAccessObject(new InMemoryUserDAO());
+        assertThrows(IOException.class, () -> dao.sendFriendRequest("a", "b"));
+    }
+
+    @Test
+    public void saveMessageDoesNotThrow() {
+        DBFriendRequestDataAccessObject dao = new DBFriendRequestDataAccessObject(new InMemoryUserDAO());
+        try {
+            dao.saveMessage("a", "b", "hi", LocalDateTime.now());
+        } catch (Exception e) {
+            fail("Should not throw");
+        }
+    }
+
+    @Test
+    public void isBlockedReturnsFalseWhenOffline() {
+        DBFriendRequestDataAccessObject dao = new DBFriendRequestDataAccessObject(new InMemoryUserDAO());
+        assertFalse(dao.isBlocked("a", "b"));
+    }
+}

--- a/src/test/java/data_access/DBMessageDataAccessObjectTest.java
+++ b/src/test/java/data_access/DBMessageDataAccessObjectTest.java
@@ -1,0 +1,26 @@
+package data_access;
+
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DBMessageDataAccessObjectTest {
+    @Test
+    public void fetchAllMessagesReturnsEmptyListWhenOffline() {
+        DBMessageDataAccessObject dao = new DBMessageDataAccessObject();
+        assertTrue(dao.fetchAllMessages().isEmpty());
+    }
+
+    @Test
+    public void saveMessageDoesNotThrow() {
+        DBMessageDataAccessObject dao = new DBMessageDataAccessObject();
+        try {
+            dao.saveMessage("a", "b", "hi", LocalDateTime.now());
+        } catch (Exception e) {
+            fail("Should not throw any exception");
+        }
+    }
+}

--- a/src/test/java/data_access/DBRecipeDataAccessObjectTest.java
+++ b/src/test/java/data_access/DBRecipeDataAccessObjectTest.java
@@ -1,0 +1,44 @@
+package data_access;
+
+import entity.Recipe;
+import entity.SearchResult;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class DBRecipeDataAccessObjectTest {
+    @Test
+    public void saveReturnsTrueEvenWhenOffline() {
+        DBRecipeDataAccessObject dao = new DBRecipeDataAccessObject();
+        SearchResult sr = new SearchResult();
+        sr.setId(1);
+        assertTrue(dao.save("user", sr));
+    }
+
+    @Test
+    public void fetchSavedRecipesThrowsWhenOffline() {
+        DBRecipeDataAccessObject dao = new DBRecipeDataAccessObject();
+        assertThrows(IOException.class, () -> dao.fetchSavedRecipes("user"));
+    }
+
+    @Test
+    public void unsaveReturnsFalseWhenOffline() {
+        DBRecipeDataAccessObject dao = new DBRecipeDataAccessObject();
+        assertFalse(dao.unsave("user", 1));
+    }
+
+    @Test
+    public void saveSharedRecipeDoesNotThrow() {
+        DBRecipeDataAccessObject dao = new DBRecipeDataAccessObject();
+        Recipe recipe = new Recipe();
+        recipe.id = 1;
+        recipe.name = "r";
+        try {
+            dao.saveSharedRecipe("a", "b", recipe);
+        } catch (Exception e) {
+            fail("Should not throw");
+        }
+    }
+}

--- a/src/test/java/data_access/DBReviewDataAccessObjectTest.java
+++ b/src/test/java/data_access/DBReviewDataAccessObjectTest.java
@@ -1,0 +1,29 @@
+package data_access;
+
+import entity.Review;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.*;
+
+public class DBReviewDataAccessObjectTest {
+    @Test
+    public void saveReturnsFalseWhenOffline() {
+        DBReviewDataAccessObject dao = new DBReviewDataAccessObject();
+        Review review = new Review(1, 5, "a", "text", LocalDateTime.now());
+        assertFalse(dao.save(review));
+    }
+
+    @Test
+    public void fetchByRecipeIdReturnsEmptyWhenOffline() {
+        DBReviewDataAccessObject dao = new DBReviewDataAccessObject();
+        assertTrue(dao.fetchByRecipeId("1").isEmpty());
+    }
+
+    @Test
+    public void fetchAllReturnsEmptyWhenOffline() {
+        DBReviewDataAccessObject dao = new DBReviewDataAccessObject();
+        assertTrue(dao.fetchAll().isEmpty());
+    }
+}

--- a/src/test/java/data_access/DBUserDataAccessObjectTest.java
+++ b/src/test/java/data_access/DBUserDataAccessObjectTest.java
@@ -1,0 +1,69 @@
+package data_access;
+
+import entity.User;
+import entity.UserFactory;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class DBUserDataAccessObjectTest {
+    private static class SimpleUser implements User {
+        private final String username;
+        private final String password;
+        SimpleUser(String username, String password) {
+            this.username = username; this.password = password;
+        }
+        @Override public String getUsername() { return username; }
+        @Override public String getPassword() { return password; }
+    }
+    private static class SimpleFactory implements UserFactory {
+        @Override public User createUser(String name, String password) { return new SimpleUser(name, password); }
+        @Override public User createUserWithHashedPassword(String name, String hashedPassword) { return new SimpleUser(name, hashedPassword); }
+    }
+
+    @Test
+    public void existsByNameReturnsFalseWhenOffline() {
+        DBUserDataAccessObject dao = new DBUserDataAccessObject(new SimpleFactory());
+        assertFalse(dao.existsByName("unknown"));
+    }
+
+    @Test
+    public void getAllUsersReturnsEmptyListWhenOffline() {
+        DBUserDataAccessObject dao = new DBUserDataAccessObject(new SimpleFactory());
+        assertTrue(dao.getAllUsers().isEmpty());
+    }
+
+    @Test
+    public void saveDoesNotThrow() {
+        DBUserDataAccessObject dao = new DBUserDataAccessObject(new SimpleFactory());
+        try {
+            dao.save(new SimpleUser("alice", "pw"));
+        } catch (Exception e) {
+            fail("Should not throw");
+        }
+    }
+
+    @Test
+    public void getReturnsNullWhenOffline() {
+        DBUserDataAccessObject dao = new DBUserDataAccessObject(new SimpleFactory());
+        assertNull(dao.get("alice"));
+    }
+
+    @Test
+    public void currentUsernameRoundTrip() {
+        DBUserDataAccessObject dao = new DBUserDataAccessObject(new SimpleFactory());
+        dao.setCurrentUsername("bob");
+        assertEquals("bob", dao.getCurrentUsername());
+    }
+
+    @Test
+    public void changePasswordThrowsRuntimeOnFailure() {
+        DBUserDataAccessObject dao = new DBUserDataAccessObject(new SimpleFactory());
+        assertThrows(RuntimeException.class, () -> dao.changePassword(new SimpleUser("alice","pw")));
+    }
+}

--- a/src/test/java/data_access/DBUserPreferenceDataAccessObjectTest.java
+++ b/src/test/java/data_access/DBUserPreferenceDataAccessObjectTest.java
@@ -1,0 +1,55 @@
+package data_access;
+
+import entity.Preferences;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class DBUserPreferenceDataAccessObjectTest {
+    private static class TestableDAO extends DBUserPreferenceDataAccessObject {
+        JSONObject savedRestrictions;
+        JSONObject savedIntolerances;
+        JSONObject fetchResponse;
+
+        @Override
+        public void saveRestrictionsAndIntolerances(String username, JSONObject r, JSONObject i) {
+            this.savedRestrictions = r;
+            this.savedIntolerances = i;
+        }
+
+        @Override
+        public JSONObject fetchRestrictionsAndIntolerances(String username) {
+            return fetchResponse;
+        }
+    }
+
+    @Test
+    public void savePreferencesSendsCorrectJSON() {
+        TestableDAO dao = new TestableDAO();
+        Map<String, Integer> diets = new HashMap<>();
+        diets.put("Vegan", 1);
+        Map<String, Integer> ints = new HashMap<>();
+        ints.put("Peanut", 1);
+        Preferences prefs = new Preferences(diets, ints);
+        dao.savePreferences("alice", prefs);
+        assertEquals(1, dao.savedRestrictions.getInt("Vegan"));
+        assertEquals(1, dao.savedIntolerances.getInt("Peanut"));
+    }
+
+    @Test
+    public void getPreferencesParsesResponse() {
+        TestableDAO dao = new TestableDAO();
+        JSONObject restrictions = new JSONObject().put("Vegan", 1);
+        JSONObject intolerances = new JSONObject().put("Peanut", 2);
+        dao.fetchResponse = new JSONObject()
+                .put("preferences", restrictions)
+                .put("intolerances", intolerances);
+        Preferences p = dao.getPreferences("alice");
+        assertEquals(Integer.valueOf(1), p.getDiets().get("Vegan"));
+        assertEquals(Integer.valueOf(2), p.getIntolerances().get("Peanut"));
+    }
+}

--- a/src/test/java/data_access/SpoonacularAPIClientTest.java
+++ b/src/test/java/data_access/SpoonacularAPIClientTest.java
@@ -1,0 +1,23 @@
+package data_access;
+
+import entity.FilterOptions;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertThrows;
+
+public class SpoonacularAPIClientTest {
+    @Test
+    public void searchByDishThrowsOnNetworkError() {
+        SpoonacularAPIClient client = new SpoonacularAPIClient("bad");
+        assertThrows(IOException.class, () -> client.searchByDish("pasta", new FilterOptions()));
+    }
+
+    @Test
+    public void loadIDsThrowsOnNetworkError() {
+        SpoonacularAPIClient client = new SpoonacularAPIClient("bad");
+        assertThrows(IOException.class, () -> client.loadIDs(Collections.singletonList(1)));
+    }
+}

--- a/src/test/java/interface_adapter/ViewManagerModelTest.java
+++ b/src/test/java/interface_adapter/ViewManagerModelTest.java
@@ -1,0 +1,13 @@
+package interface_adapter;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ViewManagerModelTest {
+    @Test
+    public void startsWithEmptyState() {
+        ViewManagerModel model = new ViewManagerModel();
+        assertEquals("", model.getState());
+    }
+}

--- a/src/test/java/interface_adapter/ViewManagerTest.java
+++ b/src/test/java/interface_adapter/ViewManagerTest.java
@@ -1,0 +1,29 @@
+package interface_adapter;
+
+import org.junit.Test;
+
+import javax.swing.*;
+import java.awt.*;
+
+import static org.junit.Assert.*;
+
+public class ViewManagerTest {
+    private static class TestCardLayout extends CardLayout {
+        String last;
+        @Override
+        public void show(Container parent, String name) {
+            last = name;
+        }
+    }
+
+    @Test
+    public void propertyChangeShowsCard() {
+        TestCardLayout layout = new TestCardLayout();
+        JPanel panel = new JPanel(layout);
+        ViewManagerModel model = new ViewManagerModel();
+        new ViewManager(panel, layout, model);
+        model.setState("view1");
+        model.firePropertyChanged();
+        assertEquals("view1", layout.last);
+    }
+}

--- a/src/test/java/interface_adapter/login/LoginPresenterAdditionalTest.java
+++ b/src/test/java/interface_adapter/login/LoginPresenterAdditionalTest.java
@@ -1,0 +1,32 @@
+package interface_adapter.login;
+
+import interface_adapter.ViewManagerModel;
+import interface_adapter.change_password.LoggedInViewModel;
+import org.junit.Test;
+import use_case.login.LoginOutputData;
+
+import static org.junit.Assert.*;
+
+public class LoginPresenterAdditionalTest {
+    @Test
+    public void successUpdatesLoggedInView() {
+        ViewManagerModel manager = new ViewManagerModel();
+        LoginViewModel loginVM = new LoginViewModel();
+        LoggedInViewModel loggedInVM = new LoggedInViewModel();
+        LoginPresenter presenter = new LoginPresenter(manager, loginVM, loggedInVM);
+        LoginOutputData data = new LoginOutputData("bob", "ok");
+        presenter.prepareSuccessView(data);
+        assertEquals("bob", loggedInVM.getState().getUsername());
+        assertEquals(loggedInVM.getViewName(), manager.getState());
+    }
+
+    @Test
+    public void failureSetsLoginError() {
+        ViewManagerModel manager = new ViewManagerModel();
+        LoginViewModel loginVM = new LoginViewModel();
+        LoggedInViewModel loggedInVM = new LoggedInViewModel();
+        LoginPresenter presenter = new LoginPresenter(manager, loginVM, loggedInVM);
+        presenter.prepareFailView("bad");
+        assertEquals("bad", loginVM.getState().getLoginError());
+    }
+}

--- a/src/test/java/interface_adapter/preferences/GetPreferencesPresenterAdditionalTest.java
+++ b/src/test/java/interface_adapter/preferences/GetPreferencesPresenterAdditionalTest.java
@@ -1,0 +1,19 @@
+package interface_adapter.preferences;
+
+import entity.Preferences;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+public class GetPreferencesPresenterAdditionalTest {
+    @Test
+    public void setsPreferencesOnPresent() {
+        PreferencesViewModel vm = new PreferencesViewModel();
+        GetPreferencesPresenter presenter = new GetPreferencesPresenter(vm);
+        Preferences prefs = new Preferences(new HashMap<>(), new HashMap<>());
+        presenter.presentPreferences(prefs);
+        assertEquals(prefs, vm.getPreferences());
+    }
+}

--- a/src/test/java/interface_adapter/preferences/PreferencesControllerAdditionalTest.java
+++ b/src/test/java/interface_adapter/preferences/PreferencesControllerAdditionalTest.java
@@ -1,0 +1,39 @@
+package interface_adapter.preferences;
+
+import entity.Preferences;
+import org.junit.Test;
+import use_case.preferences.get_preferences.GetPreferencesInputBoundary;
+import use_case.preferences.save_preferences.SavePreferencesInputBoundary;
+
+import static org.junit.Assert.*;
+
+public class PreferencesControllerAdditionalTest {
+    private static class FakeGetInteractor implements GetPreferencesInputBoundary {
+        String lastUsername;
+        @Override
+        public void execute(String username) { lastUsername = username; }
+    }
+    private static class FakeSaveInteractor implements SavePreferencesInputBoundary {
+        String user; Preferences prefs;
+        @Override
+        public void execute(String username, Preferences preferences) { user = username; prefs = preferences; }
+    }
+    @Test
+    public void loadDelegatesToGetInteractor() {
+        FakeGetInteractor get = new FakeGetInteractor();
+        FakeSaveInteractor save = new FakeSaveInteractor();
+        PreferencesController controller = new PreferencesController(get, save);
+        controller.loadPreferences("bob");
+        assertEquals("bob", get.lastUsername);
+    }
+    @Test
+    public void saveDelegatesToSaveInteractor() {
+        FakeGetInteractor get = new FakeGetInteractor();
+        FakeSaveInteractor save = new FakeSaveInteractor();
+        PreferencesController controller = new PreferencesController(get, save);
+        Preferences prefs = new Preferences(new java.util.HashMap<>(), new java.util.HashMap<>());
+        controller.savePreferences("bob", prefs);
+        assertEquals("bob", save.user);
+        assertEquals(prefs, save.prefs);
+    }
+}

--- a/src/test/java/interface_adapter/preferences/SavePreferencesPresenterAdditionalTest.java
+++ b/src/test/java/interface_adapter/preferences/SavePreferencesPresenterAdditionalTest.java
@@ -1,0 +1,23 @@
+package interface_adapter.preferences;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SavePreferencesPresenterAdditionalTest {
+    @Test
+    public void setsMessageOnSuccess() {
+        PreferencesViewModel vm = new PreferencesViewModel();
+        SavePreferencesPresenter presenter = new SavePreferencesPresenter(vm);
+        presenter.prepareSuccessView("ok");
+        assertEquals("ok", vm.getMessage());
+    }
+
+    @Test
+    public void setsMessageOnFailure() {
+        PreferencesViewModel vm = new PreferencesViewModel();
+        SavePreferencesPresenter presenter = new SavePreferencesPresenter(vm);
+        presenter.prepareFailView("error");
+        assertEquals("error", vm.getMessage());
+    }
+}

--- a/src/test/java/interface_adapter/save/SavePresenterAdditionalTest.java
+++ b/src/test/java/interface_adapter/save/SavePresenterAdditionalTest.java
@@ -1,0 +1,24 @@
+package interface_adapter.save;
+
+import org.junit.Test;
+import use_case.save.SaveOutputData;
+
+import static org.junit.Assert.*;
+
+public class SavePresenterAdditionalTest {
+    @Test
+    public void successSetsMessage() {
+        SaveViewModel vm = new SaveViewModel();
+        SavePresenter presenter = new SavePresenter(vm);
+        presenter.prepareSuccessView(new SaveOutputData("ok", null));
+        assertEquals("Saved!", vm.getSaveState().getMessage());
+    }
+
+    @Test
+    public void errorSetsMessage() {
+        SaveViewModel vm = new SaveViewModel();
+        SavePresenter presenter = new SavePresenter(vm);
+        presenter.prepareErrorView("bad");
+        assertEquals("bad", vm.getSaveState().getMessage());
+    }
+}

--- a/src/test/java/interface_adapter/search/SearchControllerTest.java
+++ b/src/test/java/interface_adapter/search/SearchControllerTest.java
@@ -1,0 +1,28 @@
+package interface_adapter.search;
+
+import entity.FilterOptions;
+import org.junit.Test;
+import use_case.search.SearchInputBoundary;
+import use_case.search.SearchInputData;
+
+import static org.junit.Assert.*;
+
+public class SearchControllerTest {
+    private static class MockInteractor implements SearchInputBoundary {
+        SearchInputData last;
+        @Override
+        public void execute(SearchInputData inputData) {
+            this.last = inputData;
+        }
+    }
+
+    @Test
+    public void handleSearchPassesInputToInteractor() {
+        MockInteractor interactor = new MockInteractor();
+        SearchController controller = new SearchController(interactor);
+        FilterOptions opts = new FilterOptions();
+        controller.handleSearch("q", opts);
+        assertEquals("q", interactor.last.getQuery());
+        assertSame(opts, interactor.last.getFilters());
+    }
+}

--- a/src/test/java/interface_adapter/search/SearchPresenterTest.java
+++ b/src/test/java/interface_adapter/search/SearchPresenterTest.java
@@ -1,0 +1,33 @@
+package interface_adapter.search;
+
+import entity.SearchResult;
+import org.junit.Test;
+import use_case.search.SearchOutputData;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+public class SearchPresenterTest {
+    @Test
+    public void successPublishesResults() {
+        SearchViewModel vm = new SearchViewModel();
+        SearchPresenter presenter = new SearchPresenter(vm);
+        SearchResult result = new SearchResult();
+        presenter.prepareSuccessView(new SearchOutputData(Collections.singletonList(result)));
+        SearchState state = vm.getState();
+        assertFalse(state.isLoading());
+        assertNull(state.getErrorMessage());
+        assertEquals(1, state.getResults().size());
+    }
+
+    @Test
+    public void failurePublishesError() {
+        SearchViewModel vm = new SearchViewModel();
+        SearchPresenter presenter = new SearchPresenter(vm);
+        presenter.prepareFailView("oops");
+        SearchState state = vm.getState();
+        assertEquals("oops", state.getErrorMessage());
+        assertFalse(state.isLoading());
+    }
+}

--- a/src/test/java/interface_adapter/signup/SignupControllerAdditionalTest.java
+++ b/src/test/java/interface_adapter/signup/SignupControllerAdditionalTest.java
@@ -1,0 +1,36 @@
+package interface_adapter.signup;
+
+import org.junit.Test;
+import use_case.signup.SignupInputBoundary;
+import use_case.signup.SignupInputData;
+
+import static org.junit.Assert.*;
+
+public class SignupControllerAdditionalTest {
+    private static class FakeInteractor implements SignupInputBoundary {
+        SignupInputData lastData;
+        boolean switched;
+        @Override
+        public void execute(SignupInputData data) { lastData = data; }
+        @Override
+        public void switchToLoginView() { switched = true; }
+    }
+
+    @Test
+    public void signupDelegatesToInteractor() {
+        FakeInteractor interactor = new FakeInteractor();
+        SignupController controller = new SignupController(interactor);
+        controller.signup("user", "p1", "p2");
+        assertEquals("user", interactor.lastData.getUsername());
+        assertEquals("p1", interactor.lastData.getPassword());
+        assertEquals("p2", interactor.lastData.getRepeatPassword());
+    }
+
+    @Test
+    public void switchToLoginDelegates() {
+        FakeInteractor interactor = new FakeInteractor();
+        SignupController controller = new SignupController(interactor);
+        controller.switchToLoginView();
+        assertTrue(interactor.switched);
+    }
+}

--- a/src/test/java/interface_adapter/signup/SignupPresenterAdditionalTest.java
+++ b/src/test/java/interface_adapter/signup/SignupPresenterAdditionalTest.java
@@ -1,0 +1,32 @@
+package interface_adapter.signup;
+
+import interface_adapter.ViewManagerModel;
+import interface_adapter.login.LoginViewModel;
+import org.junit.Test;
+import use_case.signup.SignupOutputData;
+
+import static org.junit.Assert.*;
+
+public class SignupPresenterAdditionalTest {
+    @Test
+    public void successUpdatesViewModels() {
+        ViewManagerModel manager = new ViewManagerModel();
+        SignupViewModel signupVM = new SignupViewModel();
+        LoginViewModel loginVM = new LoginViewModel();
+        SignupPresenter presenter = new SignupPresenter(manager, signupVM, loginVM);
+        SignupOutputData data = new SignupOutputData("alice", "ok");
+        presenter.prepareSuccessView(data);
+        assertEquals("alice", loginVM.getState().getUsername());
+        assertEquals(loginVM.getViewName(), manager.getState());
+    }
+
+    @Test
+    public void failureSetsErrorMessage() {
+        ViewManagerModel manager = new ViewManagerModel();
+        SignupViewModel signupVM = new SignupViewModel();
+        LoginViewModel loginVM = new LoginViewModel();
+        SignupPresenter presenter = new SignupPresenter(manager, signupVM, loginVM);
+        presenter.prepareFailView("exists");
+        assertEquals("exists", signupVM.getState().getUsernameError());
+    }
+}

--- a/src/test/java/view/AppShellTest.java
+++ b/src/test/java/view/AppShellTest.java
@@ -1,0 +1,33 @@
+package view;
+
+import org.junit.Test;
+
+import javax.swing.*;
+
+import static org.junit.Assert.*;
+
+public class AppShellTest {
+    static {
+        System.setProperty("java.awt.headless", "true");
+    }
+
+    @Test
+    public void switchesPagesOnButtonClick() {
+        JPanel search = new JPanel();
+        JPanel saved = new JPanel();
+        JPanel feed = new JPanel();
+        JPanel friends = new JPanel();
+        JPanel account = new JPanel();
+
+        AppShell shell = new AppShell(search, saved, feed, friends, account);
+
+        assertTrue(search.isVisible());
+
+        JToolBar tb = (JToolBar) shell.getComponent(0);
+        JButton savedBtn = (JButton) tb.getComponent(1);
+        savedBtn.doClick();
+
+        assertTrue(saved.isVisible());
+        assertFalse(search.isVisible());
+    }
+}

--- a/src/test/java/view/LabelTextPanelTest.java
+++ b/src/test/java/view/LabelTextPanelTest.java
@@ -1,0 +1,21 @@
+package view;
+
+import org.junit.Test;
+
+import javax.swing.*;
+import java.awt.*;
+
+import static org.junit.Assert.*;
+
+public class LabelTextPanelTest {
+    @Test
+    public void constructorSetsLayoutAndBackground() {
+        JLabel label = new JLabel("Name");
+        JTextField field = new JTextField();
+        LabelTextPanel panel = new LabelTextPanel(label, field);
+        assertTrue(panel.getLayout() instanceof FlowLayout);
+        assertEquals(new Color(238, 255, 238), panel.getBackground());
+        assertEquals(panel, label.getParent());
+        assertEquals(panel, field.getParent());
+    }
+}


### PR DESCRIPTION
## Summary
- Add tests for every data access class, exercising network-failure paths and simple operations
- Extend interface adapter coverage with SearchController and ViewManagerModel tests
- Exercise AppShell card switching to improve view layer coverage

## Testing
- `mvn -q test` *(fails: Plugin maven-resources-plugin:3.3.1 could not be resolved, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d69c04bb0832ca6fa76ccd42c3620